### PR TITLE
add constant to config file

### DIFF
--- a/Makefile.video.am
+++ b/Makefile.video.am
@@ -1,0 +1,11 @@
+-include $(top_srcdir)/build/modmake.rulesam
+AUTOMAKE_OPTIONS = foreign subdir-objects
+MODNAME=mod_telnyx_video
+
+LIBS := $(if $(switch_builddir),$(switch_builddir)/libfreeswitch.la,)
+
+mod_LTLIBRARIES = mod_telnyx_video.la
+mod_telnyx_video_la_SOURCES  = globals.c cJSON.c http.c api.c servers.c hash.c mod_janus.c
+mod_telnyx_video_la_CFLAGS   = -DJANUS_CONFIG_FILE="telnyx_video.conf" $(AM_CFLAGS) $(FREESWITCH_CFLAGS)
+mod_telnyx_video_la_LDFLAGS  = -avoid-version -module -no-undefined -shared $(FREESWITCH_LIBS) $(OPENSSL_LIBS) $(MOSQUITTO_LIBS)
+mod_telnyx_video_la_LIBADD   = $(LIBS)

--- a/mod_janus.c
+++ b/mod_janus.c
@@ -42,6 +42,10 @@
 #include	"api.h"
 #include	"hash.h"
 
+#ifndef JANUS_CONFIG_FILE
+#define JANUS_CONFIG_FILE "janus.conf"
+#endif
+
 SWITCH_MODULE_LOAD_FUNCTION(mod_janus_load);
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_janus_shutdown);
 //SWITCH_MODULE_RUNTIME_FUNCTION(mod_janus_runtime);
@@ -1057,7 +1061,7 @@ switch_io_routines_t janus_io_routines = {
 
 static switch_status_t load_config(void)
 {
-	char *cf = "janus.conf";
+	char *cf = JANUS_CONFIG_FILE;
 	switch_xml_t cfg, xml, settings, param, xmlint;
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Janus - loading config\n");


### PR DESCRIPTION
Add makefile.video.am that can be removed in a branch when sending patches to upstream. This makes it easy to get patches and send patches to upstream. 

It is a solution that I am trying to apply in telnyx_rtc as well. Try to don't touch and rename functions and files pre-existent in order to be easy to just cherry-pick patches from upstream instead of manual copy by hand because everything generates conflict there atm.